### PR TITLE
feat: ME-86a4j0h5c-finish-support-call-comand

### DIFF
--- a/src/bot/commands/utils/close.ts
+++ b/src/bot/commands/utils/close.ts
@@ -1,0 +1,59 @@
+import { SlashCommandBuilder, CommandInteraction, TextChannel, MessageCollector, Locale } from 'discord.js'
+import { DiscordCommand } from '@bot/interfaces/discordCommand'
+import { translations } from '@bot/translations'
+
+export const command: DiscordCommand = {
+	data: new SlashCommandBuilder()
+		.setName('close')
+		.setDescription('close the ticket'),
+	async execute(interaction: CommandInteraction) {
+		const channel = interaction.channel
+		const channelTypeID = channel?.type
+		const userLanguage: Locale = interaction.locale
+
+		let selectedLanguage: Locale = userLanguage
+
+		if (userLanguage !== Locale.PortugueseBR && userLanguage !== Locale.EnglishUS) {
+				selectedLanguage = Locale.PortugueseBR
+		}
+
+		const translate = translations[selectedLanguage as keyof typeof translations]['utils']['close']
+		
+		if (!channel || channelTypeID !== 12) {
+			await interaction.reply(translate['channelTypeInvalid'])
+			return
+		}
+
+		await interaction.reply('Por favor, informe o motivo do encerramento do ticket:')
+
+		const filter = (response: any) => response.author.id === interaction.user.id;
+		const collector = new MessageCollector(channel, { filter, max: 1, time: 60000 })
+
+		collector.on('collect', async (message) => {
+			const reason = message.content
+			const supportHistoryChannelId = '1272975836110127157'
+			const supportHistoryChannel = interaction.guild?.channels.cache.get(supportHistoryChannelId) as TextChannel
+			const supportHistoryMessage = `
+				**Ticket ID:** ${channel.id}
+				**Data do atendimento:** ${interaction.createdAt}
+				**Usuário:** ${interaction.user.username} (ID: ${interaction.user.id})
+				**Moderador Responsável:** ${interaction.user.tag} (ID: ${interaction.user.id})
+				**Motivo de Encerramento:** ${reason}
+			`
+
+			if (supportHistoryChannel) {
+				await supportHistoryChannel.send(supportHistoryMessage)
+			} else {
+				await interaction.followUp('Não foi possível encontrar o canal de histórico.')
+			}
+
+			await channel.delete('Ticket fechado pelo comando /close')
+		})
+
+		collector.on('end', collected => {
+			if (collected.size === 0) {
+				interaction.followUp('Você não forneceu um motivo para o encerramento do ticket. O canal não será fechado.')
+			}
+		})
+  }
+}

--- a/src/bot/commands/utils/close.ts
+++ b/src/bot/commands/utils/close.ts
@@ -1,61 +1,65 @@
-import { SlashCommandBuilder, CommandInteraction, TextChannel, MessageCollector, Locale } from 'discord.js'
+import { SlashCommandBuilder, CommandInteraction, TextChannel, Locale } from 'discord.js'
 import { DiscordCommand } from '@bot/interfaces/discordCommand'
 import { translations } from '@bot/translations'
 
 export const command: DiscordCommand = {
 	data: new SlashCommandBuilder()
 		.setName('close')
-		.setDescription('close the ticket'),
+		.setDescription('Close the ticket and provide a reason')
+		.addStringOption(option =>
+			option.setName('reason')
+				.setDescription('Reason for closing the ticket')
+				.setRequired(true)),
 	async execute(interaction: CommandInteraction) {
 		const channel = interaction.channel
 		const channelTypeID = channel?.type
+		const reason = interaction.options.get('reason', true)?.value as string
+		const mStoreId = '1201322920253857902'
+		const userWhoClosed = interaction.user.id
 		const userLanguage: Locale = interaction.locale
 
 		let selectedLanguage: Locale = userLanguage
+		let moderatorId: string | null = null
 
 		if (userLanguage !== Locale.PortugueseBR && userLanguage !== Locale.EnglishUS) {
-				selectedLanguage = Locale.PortugueseBR
+			selectedLanguage = Locale.PortugueseBR
 		}
 
 		const translate = translations[selectedLanguage as keyof typeof translations]['utils']['close']
-		
+
 		if (!channel || channelTypeID !== 12) {
 			await interaction.reply({ content: translate['channelTypeInvalid'], ephemeral: true })
 			return
 		}
 
-		await interaction.reply({ content: translate['closureReasonRequestMessage'], ephemeral: true })
+		const userToHelpId = channel.name.split('-')[1]
+		const messages = await channel.messages.fetch({ limit: 15 })
 
-		const filter = (response: any) => response.author.id === interaction.user.id;
-		const collector = new MessageCollector(channel, { filter, max: 1, time: 60000 })
-
-		collector.on('collect', async (message) => {
-			const reason = message.content
-			const supportHistoryChannelId = '1272975836110127157'
-			const supportDate = interaction.createdAt.toLocaleString(selectedLanguage, {timeZone: 'UTC'})
-			const supportHistoryChannel = interaction.guild?.channels.cache.get(supportHistoryChannelId) as TextChannel
-			const supportHistoryMessage = translate['historyMessage']
-				.replace('{id}', channel.id)
-				.replace('{createdAt}', supportDate)
-				.replace('{username}', interaction.user.username)
-				.replace('{userId}', interaction.user.id)
-				.replace('{moderatorId}', interaction.user.id)
-				.replace('{userTag}', interaction.user.tag)
-				.replace('{reason}', reason)
-
-			if (supportHistoryChannel) {
-				await supportHistoryChannel.send(supportHistoryMessage)
-			} else {
-				await interaction.followUp({ content: translate['channelNotFound'], ephemeral: true })
+		for (const message of messages.values()) {
+			if (message.author.id !== userToHelpId && message.author.id !== mStoreId) {
+				moderatorId = message.author.id
+				break
 			}
+		}
 
+		const supportHistoryChannelId = '1272975836110127157'
+		const supportHistoryChannel = interaction.guild?.channels.cache.get(supportHistoryChannelId) as TextChannel
+		const supportDate = new Date(interaction.createdAt).toLocaleString(selectedLanguage)
+		const supportHistoryMessage = translate['historyMessage']
+			.replace('{id}', channel.id)
+			.replace('{channelName}', channel.name)
+			.replace('{createdAt}', supportDate)
+			.replace('{username}', `<@${userToHelpId}>`)
+			.replace('{moderatorName}', moderatorId ? `<@${moderatorId}>` : translate['moderatorUnknown'])
+			.replace('{reason}', reason)
+			.replace('{closedBy}', `<@${userWhoClosed}>`)
+
+		await supportHistoryChannel.send(supportHistoryMessage)
+
+		await interaction.reply({ content: translate['ticketClosed'], ephemeral: true })
+
+		setTimeout(async () => {
 			await channel.delete()
-		})
-
-		collector.on('end', collected => {
-			if (collected.size === 0) {
-				interaction.followUp({ content: translate['reasonNotProvided'], ephemeral: true })
-			}
-		})
-  }
+		}, 5000)
+	}
 }

--- a/src/bot/commands/utils/close.ts
+++ b/src/bot/commands/utils/close.ts
@@ -20,11 +20,11 @@ export const command: DiscordCommand = {
 		const translate = translations[selectedLanguage as keyof typeof translations]['utils']['close']
 		
 		if (!channel || channelTypeID !== 12) {
-			await interaction.reply(translate['channelTypeInvalid'])
+			await interaction.reply({ content: translate['channelTypeInvalid'], ephemeral: true })
 			return
 		}
 
-		await interaction.reply('Por favor, informe o motivo do encerramento do ticket:')
+		await interaction.reply({ content: translate['closureReasonRequestMessage'], ephemeral: true })
 
 		const filter = (response: any) => response.author.id === interaction.user.id;
 		const collector = new MessageCollector(channel, { filter, max: 1, time: 60000 })
@@ -32,27 +32,29 @@ export const command: DiscordCommand = {
 		collector.on('collect', async (message) => {
 			const reason = message.content
 			const supportHistoryChannelId = '1272975836110127157'
+			const supportDate = interaction.createdAt.toLocaleString(selectedLanguage, {timeZone: 'UTC'})
 			const supportHistoryChannel = interaction.guild?.channels.cache.get(supportHistoryChannelId) as TextChannel
-			const supportHistoryMessage = `
-				**Ticket ID:** ${channel.id}
-				**Data do atendimento:** ${interaction.createdAt}
-				**Usuário:** ${interaction.user.username} (ID: ${interaction.user.id})
-				**Moderador Responsável:** ${interaction.user.tag} (ID: ${interaction.user.id})
-				**Motivo de Encerramento:** ${reason}
-			`
+			const supportHistoryMessage = translate['historyMessage']
+				.replace('{id}', channel.id)
+				.replace('{createdAt}', supportDate)
+				.replace('{username}', interaction.user.username)
+				.replace('{userId}', interaction.user.id)
+				.replace('{moderatorId}', interaction.user.id)
+				.replace('{userTag}', interaction.user.tag)
+				.replace('{reason}', reason)
 
 			if (supportHistoryChannel) {
 				await supportHistoryChannel.send(supportHistoryMessage)
 			} else {
-				await interaction.followUp('Não foi possível encontrar o canal de histórico.')
+				await interaction.followUp({ content: translate['channelNotFound'], ephemeral: true })
 			}
 
-			await channel.delete('Ticket fechado pelo comando /close')
+			await channel.delete()
 		})
 
 		collector.on('end', collected => {
 			if (collected.size === 0) {
-				interaction.followUp('Você não forneceu um motivo para o encerramento do ticket. O canal não será fechado.')
+				interaction.followUp({ content: translate['reasonNotProvided'], ephemeral: true })
 			}
 		})
   }

--- a/src/bot/translations/en-US.ts
+++ b/src/bot/translations/en-US.ts
@@ -32,13 +32,15 @@ const commands = {
 			channelTypeInvalid: 'The command cannot be used in this channel.',
 			closureReasonRequestMessage: 'Please provide the reason for closing the ticket:',
 			historyMessage: 
-				'**Ticket ID:** {id}'+
-				'\n\n**Date of service:** `{createdAt}`'+
-				'\n**User:** `@{username}` \ `ID: {userId}`'+
-				'\n**Responsible moderator:** `@{userTag}` \ `ID: {moderatorId}`'+
-				'\n**Reason for closure:** ```{reason}```',
-			channelNotFound: 'Could not find the history channel.',
-			reasonNotProvided: 'You did not provide a reason for closing the ticket. The channel will not be closed.'
+				'**Ticket ID: ** {id}'+
+				'\n\n**Channel Name: ** `{channelName}`'+
+				'\n**Date of service: ** `{createdAt}`'+
+				'\n**User: ** {username}'+
+				'\n**Responsible moderator: ** {moderatorName}'+
+				'\n**Support closed by: ** {closedBy}'+
+				'\n**Reason for closure: ** ```{reason}```',
+			moderatorUnknown: 'Not assigned',
+			ticketClosed: "Support closed successfully! The channel will be closed in 5 seconds."
 		}
 	}
 }

--- a/src/bot/translations/en-US.ts
+++ b/src/bot/translations/en-US.ts
@@ -27,6 +27,9 @@ const commands = {
 			answerCall: {
 				supportEnter: '<@{userToSupportId}>, support member: <@{userId}> joined the chat.'
 			}
+		},
+		close: {
+			channelTypeInvalid: 'The command cannot be used in this channel.'
 		}
 	}
 }

--- a/src/bot/translations/en-US.ts
+++ b/src/bot/translations/en-US.ts
@@ -29,7 +29,16 @@ const commands = {
 			}
 		},
 		close: {
-			channelTypeInvalid: 'The command cannot be used in this channel.'
+			channelTypeInvalid: 'The command cannot be used in this channel.',
+			closureReasonRequestMessage: 'Please provide the reason for closing the ticket:',
+			historyMessage: 
+				'**Ticket ID:** {id}'+
+				'\n\n**Date of service:** `{createdAt}`'+
+				'\n**User:** `@{username}` \ `ID: {userId}`'+
+				'\n**Responsible moderator:** `@{userTag}` \ `ID: {moderatorId}`'+
+				'\n**Reason for closure:** ```{reason}```',
+			channelNotFound: 'Could not find the history channel.',
+			reasonNotProvided: 'You did not provide a reason for closing the ticket. The channel will not be closed.'
 		}
 	}
 }

--- a/src/bot/translations/pt-BR.ts
+++ b/src/bot/translations/pt-BR.ts
@@ -32,13 +32,15 @@ const commands = {
 			channelTypeInvalid: 'O comando não pode ser usado nesse canal.',
 			closureReasonRequestMessage: 'Por favor, informe o motivo do encerramento do ticket:',
 			historyMessage: 
-				'**Ticket ID:** {id}'+
-				'\n\n**Data do atendimento:** `{createdAt}`'+
-				'\n**Usuário:** `@{username}` \ `ID: {userId}`'+
-				'\n**Moderador responsável:** `@{userTag}` \ `ID: {moderatorId}`'+
-				'\n**Motivo de encerramento:** ```{reason}```',
-			channelNotFound: 'Não foi possível encontrar o canal de histórico.',
-			reasonNotProvided: 'Você não forneceu um motivo para o encerramento do ticket. O canal não será fechado.'
+				'**Ticket ID: ** {id}'+
+				'\n\n**Nome do canal: ** `{channelName}`'+
+				'\n**Data do atendimento: ** `{createdAt}`'+
+				'\n**Usuário: ** {username}'+
+				'\n**Moderador responsável: ** {moderatorName}'+
+				'\n**Atendimento encerrado por: ** {closedBy}'+
+				'\n**Motivo de encerramento: ** ```{reason}```',
+			moderatorUnknown: 'Não atribuído',
+			ticketClosed: "Atendimento encerrado com sucesso! O canal será fechado em 5 segundos."
 		}
 	}
 }

--- a/src/bot/translations/pt-BR.ts
+++ b/src/bot/translations/pt-BR.ts
@@ -29,7 +29,16 @@ const commands = {
 			}
 		},
 		close: {
-			channelTypeInvalid: 'O comando não pode ser usado nesse canal.'
+			channelTypeInvalid: 'O comando não pode ser usado nesse canal.',
+			closureReasonRequestMessage: 'Por favor, informe o motivo do encerramento do ticket:',
+			historyMessage: 
+				'**Ticket ID:** {id}'+
+				'\n\n**Data do atendimento:** `{createdAt}`'+
+				'\n**Usuário:** `@{username}` \ `ID: {userId}`'+
+				'\n**Moderador responsável:** `@{userTag}` \ `ID: {moderatorId}`'+
+				'\n**Motivo de encerramento:** ```{reason}```',
+			channelNotFound: 'Não foi possível encontrar o canal de histórico.',
+			reasonNotProvided: 'Você não forneceu um motivo para o encerramento do ticket. O canal não será fechado.'
 		}
 	}
 }

--- a/src/bot/translations/pt-BR.ts
+++ b/src/bot/translations/pt-BR.ts
@@ -27,6 +27,9 @@ const commands = {
 			answerCall: {
 				supportEnter: '<@{userToSupportId}>, o membro do suporte: <@{userId}> entrou no chat.'
 			}
+		},
+		close: {
+			channelTypeInvalid: 'O comando não pode ser usado nesse canal.'
 		}
 	}
 }


### PR DESCRIPTION
**Principal change:**

- The command to close the support has been created
- When executing the /close command, a message about the support history is sent to the support history channel